### PR TITLE
refactor

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -43,7 +43,7 @@ const DEFAULT_TEMPLATES_DIR = path.resolve(ROOT_DIR, 'node_modules');
 
 const TRANSPILED_TEMPLATE_LOCATION = '__transpiled';
 const TEMPLATE_CONTENT_DIRNAME = 'template';
-const GENERATOR_OPTIONS = ['debug', 'disabledHooks', 'entrypoint', 'forceWrite', 'install', 'noOverwriteGlobs', 'output', 'templateParams', 'mapBaseUrlToFolder', 'url', 'username', 'password', 'token', 'registry'];
+const GENERATOR_OPTIONS = ['debug', 'disabledHooks', 'entrypoint', 'forceWrite', 'install', 'noOverwriteGlobs', 'output', 'templateParams', 'mapBaseUrlToFolder', 'url', 'auth', 'token', 'registry'];
 const logMessage = require('./logMessages');
 
 const shouldIgnoreFile = filePath =>
@@ -86,9 +86,8 @@ class Generator {
    * @param {Object<String, String>} [options.mapBaseUrlToFolder] Optional parameter to map schema references from a base url to a local base folder e.g. url=https://schema.example.com/crm/  folder=./test/docs/ .
    * @param {Object} [options.registry]           Optional parameter with private registry configuration
    * @param {String} [options.registry.url]       Parameter to pass npm registry url
-   * @param {String} [options.registry.username]  Optional parameter to pass npm registry username
-   * @param {String} [options.registry.password]  Optional parameter to pass npm registry base64 encoded password
-   * @param {String} [options.registry.token]     Optional parameter to pass npm registry auth token
+   * @param {String} [options.registry.auth]      Optional parameter to pass npm registry username and password encoded with base64, formatted like username:password value should be encoded
+   * @param {String} [options.registry.token]     Optional parameter to pass npm registry auth token that you can grab from .npmrc file
    */
 
   constructor(templateName, targetDir, { templateParams = {}, entrypoint, noOverwriteGlobs, disabledHooks, output = 'fs', forceWrite = false, install = false, debug = false, mapBaseUrlToFolder = {}, registry = {}} = {}) {
@@ -526,10 +525,26 @@ class Generator {
    * @param {Object} arbOptions ArbOptions to intialise the Registry details.
    */
   initialiseArbOptions(arbOptions) {
-    if (this.registry.url) arbOptions.registry = this.registry.url;
-    if (this.registry.username) arbOptions.username = this.registry.username;
-    if (this.registry.password) arbOptions.password = this.registry.password;
-    if (this.registry.token) arbOptions.token = this.registry.token;
+    let registryUrl = 'registry.npmjs.org';
+    let authorizationName = 'anonymous';
+    const providedRegistry = this.registry.url;
+
+    if (providedRegistry) {
+      arbOptions.registry = providedRegistry;
+      registryUrl = providedRegistry;
+    }
+
+    //doing basic if/else so basically only one auth type is used and token as more secure is primary
+    if (this.registry.token) {
+      authorizationName = `//${registryUrl}:_authToken`;
+      arbOptions.authorizationName = this.registry.token;
+    } else if (this.registry.auth) {
+      authorizationName = `//${registryUrl}:_auth`;
+      arbOptions.authorizationName = this.registry.auth;
+    } 
+
+    //not sharing in logs neither token nor auth for security reasons
+    log.debug(`Using npm registry ${registryUrl} and authorization type ${authorizationName} to handle template installation.`);
   }
   /**
    * Downloads and installs a template and its dependencies
@@ -555,7 +570,7 @@ class Generator {
             path: pkgPath
           });
         } catch (e) {
-          log.debug(logMessage.packageNotAvailable(pkgPath), e);
+          log.debug(logMessage.packageNotAvailable(installedPkg), e);
           // We did our best. Proceed with installation...
         }
       }

--- a/lib/logMessages.js
+++ b/lib/logMessages.js
@@ -18,8 +18,12 @@ function templateNotFound(templateName) {
   return `${templateName} not found in local dependencies but found it installed as a global package.`;
 } 
 
-function packageNotAvailable(pkgPath) {
-  return `Unable to resolve template location at ${pkgPath}. Package is not available locally.`;
+function packageNotAvailable(packageDetails) {
+  if (packageDetails && packageDetails.pkgPath) {
+    return `Unable to resolve template location at ${packageDetails.pkgPath}. Package is not available locally.`;
+  } 
+
+  return `Template is not available locally and expected location is undefined. Known details are: ${JSON.stringify(packageDetails, null, 2)}`;
 }
 
 function installationDebugMessage(debugMessage) {

--- a/test/test-project/README.md
+++ b/test/test-project/README.md
@@ -6,5 +6,6 @@ The version of the html-template must be hardcoded to version `0.16.0` because t
 There are two custom test scripts:
 - `npm test:project` starts library integration tests that can run the same way both on local and CI
 - `npm test:global` always fail on local as it tests installation of template under global location. This would mean you have to install template globally before running the test. It means messing with your developer setup. Instead you have a docker compose configuration that you can use to run all tests from the test project in an isolated environment
+- `npm test:registry` is for testing arborist functionality to use custom private registry
 
-Instead of running tests with `npm test`, make sure you have Docker Compose and run `NODE_IMAGE_TAG=14 docker-compose up`.
+Instead of running tests with `npm test`, make sure you have Docker Compose and run `NODE_IMAGE_TAG=18 docker-compose up --abort-on-container-exit`.

--- a/test/test-project/docker-compose.yml
+++ b/test/test-project/docker-compose.yml
@@ -8,12 +8,27 @@ services:
       - '4873:4873'
     volumes:
       - './verdaccio:/verdaccio/conf'
+    networks:
+      - mynetwork
 
-  test:
+  test-project:
     privileged: true
     image: "node:${NODE_IMAGE_TAG}"
-    environment:
-      - PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
     volumes:
       - ../../:/app
-    command: bash /app/test/test-project/test.sh
+    command: bash /app/test/test-project/test.sh test-project
+
+  test-registry:
+    privileged: true
+    image: "node:${NODE_IMAGE_TAG}"
+    volumes:
+      - ../../:/app
+    command: bash /app/test/test-project/test.sh test-registry
+    networks:
+      - mynetwork
+    depends_on:
+      - verdaccio
+
+networks:
+  mynetwork:
+    driver: bridge

--- a/test/test-project/package.json
+++ b/test/test-project/package.json
@@ -1,8 +1,8 @@
 {
     "description": "Test project. More info in the readme.",
     "scripts": {
-        "test": "npm run test:cleanup && npm run test:project && npm run test:global",
-        "test:project": "jest --detectOpenHandles --testPathIgnorePatterns=test-global --modulePathIgnorePatterns='./__mocks__'",
+        "test": "npm run test:cleanup && npm run test:project && npm run test:global && npm run test:registry",
+        "test:project": "jest --detectOpenHandles --testPathPattern=test-project/test-project --modulePathIgnorePatterns='./__mocks__'",
         "test:global": "jest --detectOpenHandles --testPathPattern=test-global --modulePathIgnorePatterns='./__mocks__'",
         "test:registry": "jest --detectOpenHandles --testPathPattern=test-registry --modulePathIgnorePatterns='./__mocks__'",
         "test:cleanup": "rimraf \"../temp\""

--- a/test/test-project/test-registry.test.js
+++ b/test/test-project/test-registry.test.js
@@ -4,8 +4,8 @@
 
 const { readFile } = require('fs').promises;
 const path = require('path');
-const Generator = require('../lib/generator');
-const dummySpecPath = path.resolve(__dirname, './docs/dummy.yml');
+const Generator = require('@asyncapi/generator');
+const dummySpecPath = path.resolve(__dirname, '../docs/dummy.yml');
 const crypto = require('crypto');
 const mainTestResultPath = 'test/temp/integrationTestResult';
 
@@ -20,8 +20,18 @@ describe('Integration testing generateFromFile() to make sure the template can b
   it('generated using private registory', async () => {
     const outputDir = generateFolderName();
     const generator = new Generator('@asyncapi/html-template@0.16.0', outputDir,
-      { forceWrite: true, templateParams: { singleFile: true },
-        registry: {url: 'http://localhost:4873/', username: 'admin', password: 'nimbda'}});
+      { 
+        debug: true,
+        install: true, 
+        forceWrite: true, 
+        templateParams: { 
+          singleFile: true 
+        },
+        registry: {
+          url: 'http://verdaccio:4873', 
+          auth: 'YWRtaW46bmltZGE=' // YWRtaW46bmltZGE= is encoded with base64 username and password -> admin:nimda
+        }
+      });
     await generator.generateFromFile(dummySpecPath);
     const file = await readFile(path.join(outputDir, 'index.html'), 'utf8');
     expect(file).toContain('Dummy example with all spec features included');

--- a/test/test-project/test.sh
+++ b/test/test-project/test.sh
@@ -1,15 +1,40 @@
 #!/bin/bash
 
-#required by GitHub Actions
+# Function to install and test a specific project
+function test_project {
+  npm run test:project
+  # Installing html template globally before global tests
+  PUPPETEER_SKIP_DOWNLOAD=true npm install -g @asyncapi/html-template@0.16.0
+  # Remove previously installed html template to make sure it is not picked up in the test
+  rm -rf node_modules/@asyncapi/html-template
+  rm -rf ../../node_modules/@asyncapi/html-template
+  npm run test:global
+}
+
+# Function to test the registry
+function test_registry {
+  npm run test:registry
+}
+
+# Required by GitHub Actions
 sudo chown -R 1001:121 "/root/.npm"
+
+# Always run these steps
 cd app
 npm install
 cd test/test-project
 npm install
-npm run test:project
-#installing html template globally before global tests
-PUPPETEER_SKIP_DOWNLOAD=true npm install -g @asyncapi/html-template@0.16.0
-#remove previously installed html template to make sure it is not picked up in the test
-rm -rf node_modules/@asyncapi/html-template
-rm -rf ../../node_modules/@asyncapi/html-template
-npm run test:global
+
+# Run the functions based on the provided arguments
+case "$1" in
+  "test-project")
+    test_project
+    ;;
+  "test-registry")
+    test_registry
+    ;;
+  *)
+    echo "Invalid argument. Supported arguments: test-project, test-registry"
+    exit 1
+    ;;
+esac

--- a/test/test-project/verdaccio/config.yaml
+++ b/test/test-project/verdaccio/config.yaml
@@ -7,7 +7,7 @@ uplinks:
   npmjs:
     url: https://registry.npmjs.org/
 packages:
-  "@*/*":
-    access: $authenticated
+  "**":
+    access: admin
     proxy: npmjs
 log: { type: stdout, format: pretty, level: debug }


### PR DESCRIPTION
please go through changes and see readme so you know how to run docker now

I identified issue with arborist, different options work there

I tested with external project

```
const Arborist = require('@npmcli/arborist');

async function dupa(){

    const arbOptions = {
        path: './',
        registry: 'http://localhost:4873',
        //'//localhost:4873/:_authToken': 'G3KoBlYDfuLgRGWii1gKlw=='
        '//localhost:4873/:_auth': 'YWRtaW46bmltZGE='
    };

    const arb = new Arborist(arbOptions);

    await arb.reify({
        add: ['@asyncapi/html-template'],
        saveType: 'prod',
        save: false
    });
}

dupa()
```

notice this part `'//localhost:4873/:_auth': 'YWRtaW46bmltZGE='` - `YWRtaW46bmltZGE=` is base64 encoded value `admin:nimda` - the only way that this can work

the problem is that this script works well with `verdaccio` that I start with docker compose, through link `localhost:4873`
but generator still fails with `Unable to authenticate, need: Basic, Bearer`. Please pull my implementation and look, maybe because I worked on it all day, my eyes are tired

anyway in test you will notice `http://verdaccio:4873` as url of registry - it is because this is what chatGPT told me, that the only way to access verdaccio service, from test script that is another service, is through container name